### PR TITLE
(GP-4.1) Fixed workToTree to build and return root tree hash

### DIFF
--- a/GP41Tester.java
+++ b/GP41Tester.java
@@ -1,0 +1,73 @@
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+
+public class GP41Tester {
+    public static void main(String[] args) throws Exception {
+
+        // 1. init repository
+        Git.milestone21();
+
+        // 2. create nested folder structure
+    
+        File root = new File("Samples");
+        File dirA = new File(root, "A");
+        File dirB = new File(dirA, "B");
+        File dirC = new File(dirB, "C");
+        dirC.mkdirs();
+
+        File file1 = new File(root, "file1.txt");
+        File file2 = new File(dirA, "file2.txt");
+        File file3 = new File(dirB, "file3.txt");
+        File file4 = new File(dirC, "file4.txt");
+        File file5 = new File(dirC, "file5.txt");
+
+        Files.writeString(file1.toPath(), "root level file");
+        Files.writeString(file2.toPath(), "file in A");
+        Files.writeString(file3.toPath(), "file in B");
+        Files.writeString(file4.toPath(), "first file in C");
+        Files.writeString(file5.toPath(), "second file in C");
+
+        System.out.println("created nested files");
+
+        // 3. Stage all files (adds blobs and updates index)
+        for (File f : List.of(file1, file2, file3, file4, file5)) {
+            String hash = Git.hashFile(f.getAbsolutePath());
+            Git.createBlobFiles(f.getAbsolutePath());
+            Git.updateIndex(hash, f.getAbsolutePath());
+            System.out.println("Staged " + f.getPath());
+        }
+
+        // 4. Generate trees from index
+        System.out.println("Building trees");
+        String rootHash = null;
+        try {
+            // if workToTree returns a String
+            rootHash = Git.workToTree();
+        } catch (Exception e) {
+            // if it’s void
+            Git.workToTree();
+        }
+
+        // 5. Print root tree hash if available
+        if (rootHash != null) {
+            System.out.println("Root tree SHA: " + rootHash);
+        } else {
+            System.out.println("Root tree created (check git/objects for the newest tree file).");
+        }
+
+        // 6. List objects for manual verification
+        File objectsDir = new File("git/objects");
+        File[] objs = objectsDir.listFiles();
+        if (objs == null || objs.length == 0) {
+            System.out.println("No objects found.");
+        } else {
+            System.out.println("Objects in git/objects:");
+            for (File o : objs) {
+                System.out.println(" - " + o.getName());
+            }
+        }
+
+        System.out.println("Done. Now open your tree files to manually verify structure.");
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,22 @@ If you run the the main method, it will run my milestone21 method. This method f
 My tester ensures that all the git repository initialization is working. I ran it 5 times for maximum robustness and printed the number of the test and when it was created vs erased/deleted. I also made sure that everything is named something that is understandable. I considered edge cases where each directory or file already existed.
 
 I used the same functionality that was used in FileWriter to create a SHA-1 hash code which is the same as 256 except you just rewrite 256 to 1. Also I used a helper to convert from bytes to hexidecimal.
+
+
+GP-4.1: 
+    Issue (Before Fix): The code successfully staged files and createf blob objects, but the tree-building process (workToTree) never returned or finalized the root tree. It stopped part-way through collapsing directories. As a result, there was no way to identify the final root tree hash or verify that the directory snapshot was complete.
+
+    Fix Implemented:
+    To resolve this, I modified the method header from
+        public static void workToTree() throws Exception
+    to
+        public static String workToTree() throws Exception.
+
+    Inside the method, I:
+        Added a variable lastTreeHash to track the most recently created tree.
+        Updated the loop so that each new tree stores its hash in lastTreeHash.
+        Added a final step after the collapsing loop that builds the root tree from any remaining lines in the working list.
+        Returned the final lastTreeHash so the root tree’s SHA can be printed and verified.
+
+    Verification:
+    I wrote a simple tester (GP41Tester.java) to initialize the respository, create nested folders and sample files, stage all files (generate blobs and udpate the index), and call workToTree() and print the root tree SHA. After running the tester, tree and blob files were successfully created in git/objects/, and the root tree SHA printed correctly.

--- a/Samples/A/B/C/file4.txt
+++ b/Samples/A/B/C/file4.txt
@@ -1,0 +1,1 @@
+first file in C

--- a/Samples/A/B/C/file5.txt
+++ b/Samples/A/B/C/file5.txt
@@ -1,0 +1,1 @@
+second file in C

--- a/Samples/A/B/file3.txt
+++ b/Samples/A/B/file3.txt
@@ -1,0 +1,1 @@
+file in B

--- a/Samples/A/file2.txt
+++ b/Samples/A/file2.txt
@@ -1,0 +1,1 @@
+file in A

--- a/Samples/Inner/file2.txt
+++ b/Samples/Inner/file2.txt
@@ -1,0 +1,1 @@
+content two

--- a/Samples/file1.txt
+++ b/Samples/file1.txt
@@ -1,0 +1,1 @@
+root level file


### PR DESCRIPTION
I fixed the tree-building process for Milestone GP-4.1. Before, workToTree() made some tree files but never finished creating or returning the root tree, so the snapshot wasn’t complete. I changed the method to return a String and added code to keep track of the last tree hash and build the final root tree at the end. Now it returns the full root tree hash so it’s easy to verify. I also made a small tester (GP41Tester.java) to check that blobs and trees are created correctly in git/objects.
